### PR TITLE
Changed WG to Team

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ this repository, you can try:
 * [Freenode #node.js channel](https://webchat.freenode.net/?channels=node.js&uio=d4)
 * [Gitter Node.js room](https://gitter.im/nodejs/node)
 
-## Help WG Members
+## Help Team Members
 
 Want to help others with issues? You can start simply, by answering open questions.
 * [Mikeal Rogers](http://github.com/mikeal) - [@mikeal](http://twitter.com/mikeal)


### PR DESCRIPTION
As discussed at collaborators summit in Austin, the entity running this repo is no working group as such.
To stay consistent with the naming conventions, I was asked to rename it to 'Team'