### PR TITLE
Remove help team members list

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,5 @@ this repository, you can try:
 * [Freenode #node.js channel](https://webchat.freenode.net/?channels=node.js&uio=d4)
 * [Gitter Node.js room](https://gitter.im/nodejs/node)
 
-## Help Team Members
-
+## Participation
 Want to help others with issues? You can start simply, by answering open questions.
-* [Mikeal Rogers](http://github.com/mikeal) - [@mikeal](http://twitter.com/mikeal)
-* [Minwoo Jung](https://github.com/JungMinu) - [@jmwsoft](https://twitter.com/jmwsoft)
-* [Ross Kukulinski](http://github.com/rosskukulinski) - [@rosskukulinski](http://twitter.com/rosskukulinski)
-* [Emily Rose](https://github.com/emilyrose) -  [@nexxylove](https://twitter.com/nexxylove)
-* [Julian Duque](https://github.com/julianduque) - [@julian_duque](https://twitter.com/julian_duque)
-* [Tierney Coren](https://github.com/bnb) - [@bitandbang](https://twitter.com/bitandbang)
-* [Yosuke Furukawa](https://github.com/yosuke-furukawa) - [@yosuke-furukawa](https://twitter.com/yosuke_furukawa)
-* [Tony Pujals](https://github.com/tonypujals) - [@subfuzion](https://twitter.com/subfuzion)
-* [Giovanny Andres Gongora Granada](https://github.com/Gioyik) - [@Gioyik](https://twitter.com/Gioyik)


### PR DESCRIPTION
As pointed out by @williamkapke in https://github.com/nodejs/help/pull/387, the list of help team members is neither recent nor does it reflect any level of participation. Answering questions should most probably be seen as a joint community effort. Maybe creating a automatically updated list of most frequently participating persons would provide some level of acknowledgement. 