### PR TITLE
build: add stale issue action

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,36 @@
+name: Close stale issues
+on:
+  workflow_dispatch:
+  schedule:
+    # Run every day at 1:00 AM UTC.
+    - cron: 0 1 * * *
+
+# yamllint disable rule:empty-lines
+env:
+  CLOSE_MESSAGE: >
+    There has been no activity on this issue
+    and it is being closed. If you feel closing this issue is not the
+    right thing to do, please leave a comment.
+  WARN_MESSAGE: >
+    There has been no activity on this issue for
+    3 years and it may no longer be relevant.
+    It will be closed 1 month after the last non-automated comment.
+# yamllint enable
+
+jobs:
+  stale:
+    if: github.repository == 'nodejs/help'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # 3 years. this number is chosen to target around 25 initial issues, with then a natural flow as time progresses
+          days-before-stale: 1095 
+          days-before-close: 30
+          stale-issue-label: stale
+          close-issue-message: ${{ env.CLOSE_MESSAGE }}
+          stale-issue-message: ${{ env.WARN_MESSAGE }}
+          # max requests it will send per run to the GitHub API before it deliberately exits to avoid hitting API rate limits
+          operations-per-run: 30
+          remove-stale-when-updated: true


### PR DESCRIPTION
closes https://github.com/nodejs/admin/issues/757

Draws off of https://github.com/nodejs/node/pull/42085 to implement very generous stale issue management to the help repo.

As an initial draft I am targeting a 3 year staleness mark - which would mark [these issues](https://github.com/nodejs/help/issues?q=is%3Aopen+updated%3A%3C2020-01-12+sort%3Aupdated-asc+)

Since this is the first time a workflow action is in this repo - I am unsure if anything else needs to be configured on the admin side.