### PR TITLE
Decrease stalebot interval per collab summit discussion

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -8,13 +8,11 @@ on:
 # yamllint disable rule:empty-lines
 env:
   CLOSE_MESSAGE: >
-    There has been no activity on this issue
-    and it is being closed. If you feel closing this issue is not the
-    right thing to do, please leave a comment.
+    Closing after no activity on this issue for 9 months. 
   WARN_MESSAGE: >
-    There has been no activity on this issue for 90 days.
+    There has been no activity on this issue for 8 months.
     The help repository works best when sustained engagement moves conversation forward.
-    The issue will be closed 1 month after the last non-automated comment.
+    The issue will be closed in 1 month.
     If you are still experiencing this issue on the latest supported versions of Node.js, please leave a comment.
 # yamllint enable
 
@@ -26,7 +24,7 @@ jobs:
       - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da #4.1.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: 90
+          days-before-stale: 240 # 8 months
           days-before-close: 30
           stale-issue-label: stale
           close-issue-message: ${{ env.CLOSE_MESSAGE }}

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -8,9 +8,9 @@ on:
 # yamllint disable rule:empty-lines
 env:
   CLOSE_MESSAGE: >
-    Closing after no activity on this issue for 9 months. 
+    Closing after no activity on this issue for 12 months. 
   WARN_MESSAGE: >
-    There has been no activity on this issue for 8 months.
+    There has been no activity on this issue for 11 months.
     The help repository works best when sustained engagement moves conversation forward.
     The issue will be closed in 1 month.
     If you are still experiencing this issue on the latest supported versions of Node.js, please leave a comment.
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da #4.1.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: 240 # 8 months
+          days-before-stale: 330 # 11 months
           days-before-close: 30
           stale-issue-label: stale
           close-issue-message: ${{ env.CLOSE_MESSAGE }}

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -12,9 +12,10 @@ env:
     and it is being closed. If you feel closing this issue is not the
     right thing to do, please leave a comment.
   WARN_MESSAGE: >
-    There has been no activity on this issue for
-    3 years and it may no longer be relevant.
-    It will be closed 1 month after the last non-automated comment.
+    There has been no activity on this issue for 90 days.
+    The help repository works best when sustained engagement moves conversation forward.
+    The issue will be closed 1 month after the last non-automated comment.
+    If you are still experiencing this issue on the latest supported versions of Node.js, please leave a comment.
 # yamllint enable
 
 jobs:
@@ -22,11 +23,10 @@ jobs:
     if: github.repository == 'nodejs/help'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da #4.1.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          # 3 years. this number is chosen to target around 25 initial issues, with then a natural flow as time progresses
-          days-before-stale: 1095
+          days-before-stale: 90
           days-before-close: 30
           stale-issue-label: stale
           close-issue-message: ${{ env.CLOSE_MESSAGE }}


### PR DESCRIPTION
At the Node.js Collab Summit in September, I presented a small quantitative analysis of this repository's growth.

<img width="638" alt="image" src="https://github.com/nodejs/help/assets/298435/1360d1bb-b865-4ba3-816d-38766984c984">

Within https://github.com/nodejs/admin/issues/830 a group of us collaborators discussed actions to make the triage experience better here. Among the consensus at the meeting was to emphasize timely engagement here to avoid stale issues from going unanswered. That doesn't respect askers time or triagers time wading through years' old questions.

The goal with this action and more is to level-up the triage and help posture to such a degree that our aggregate triaging efforts can be best funneled toward the issues where posters remain committed to receiving help.