### PR TITLE
hotfix: restore logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <a href="https://nodejs.org/">
     <img
       alt="Node.js"
-      src="https://nodejs.org/static/images/logo-light.svg"
+      src="https://nodejs.org/static/images/logos/stacked-dark.svg"
       width="400"
     />
   </a>


### PR DESCRIPTION
This image moved and was renamed as part of the website redesign.

I used [archive.org](https://web.archive.org/web/20220319130608/https://github.com/nodejs/help) to ensure it's the right one (despite the name flop).

![image](https://github.com/nodejs/help/assets/298435/aecb476c-c9be-4d99-af67-3ad4fbea3ca6)
