### PR TITLE
hotfix: restore logo image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://nodejs.org/">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://nodejs.org/static/images/logos/nodejs-new-pantone-white.svg">
-      <img src="https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg" width="200px">
+      <source media="(prefers-color-scheme: dark)" srcset="https://nodejs.org/static/logos/nodejsStackedLight.svg">
+      <img src="https://nodejs.org/static/logos/nodejsStackedDark.svg" width="200px">
     </picture>
   </a>
   <h1 align="center">Help</h1>


### PR DESCRIPTION
The old logo images moved and were renamed as part of the website redesign.

I use official stacked logo from [Branding of Node.js](https://nodejs.org/en/about/branding).

### Light ver
![Light ver](https://nodejs.org/static/logos/nodejsStackedLight.svg)

### Black ver
![Black ver](https://nodejs.org/static/logos/nodejsStackedDark.svg)