### PR TITLE
Enable cache storage for stalebot

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -32,6 +32,7 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
+  actions: write
 jobs:
   stale:
     if: github.repository == 'nodejs/help'

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -38,7 +38,7 @@ jobs:
     if: github.repository == 'nodejs/help'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e #v9.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 180

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -38,7 +38,7 @@ jobs:
     if: github.repository == 'nodejs/help'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9.0.0
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 180


### PR DESCRIPTION
This PR should make the Stalebot more efficient via allowing it to utilize GitHub caching, which needs actions write permissions in order to update the existing cache.